### PR TITLE
Fix question 6

### DIFF
--- a/questions/05.md
+++ b/questions/05.md
@@ -16,7 +16,7 @@ Consider the following code:
 class User
   attr_accessor :name, :age, :location, :user_name
 
-  def initialize(user_name:, name:, age:, location:)
+  def initialize(user_name, name, age, location)
     @user_name = user_name
     @name = name
     @location = location


### PR DESCRIPTION
Updates question 6 so that keyword arguments aren't used as part of the example code, since keyword arguments are listed as a concept related to mass assignment in our curriculum.

Closes #1